### PR TITLE
docs: update README for TVMaze pivot, endpoints, and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
-# React + Vite
+# Show Explorer (React + Vite)
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A small React app for browsing **TV shows** using the public **TVMaze API** (no API key required).  
+Features include a “Now Airing (US)” view, search with client-side paging, and a show detail page with cast.
 
-Currently, two official plugins are available:
+## Tech
+- React + Vite
+- React Router
+- Simple state management with `useState` / `useEffect`
+- Async data fetching with `fetch`
+- Lightweight styling with inline styles + skeletons + error banners
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Getting Started
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+```bash
+npm install
+npm run dev


### PR DESCRIPTION

	•	Refresh README to reflect TVMaze (no API key).
	•	Document endpoints: /schedule, /search/shows, /shows/{id}?embed=cast.
	•	Update setup, structure, and limitations.
